### PR TITLE
adding compatibility with payload generation

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -31,17 +31,6 @@ app.configure(rest())
   .use('/users', memory())
   .use(errorHandler());
 
-function customizeJWTPayload() {
-  return function(hook) {
-    console.log('Customizing JWT Payload');
-    hook.data.payload = {
-      id: hook.params.user.id
-    };
-
-    return Promise.resolve(hook);
-  };
-}
-
 function customizeTwitterProfile() {
   return function(hook) {
     console.log('Customizing Twitter Profile');
@@ -61,8 +50,7 @@ function customizeTwitterProfile() {
 app.service('authentication').hooks({
   before: {
     create: [
-      auth.hooks.authenticate('jwt'),
-      customizeJWTPayload()
+      auth.hooks.authenticate('jwt')
     ]
   }
 });

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chai": "^3.5.0",
     "express-session": "^1.14.2",
     "feathers": "^2.0.2",
-    "feathers-authentication": "^1.0.0-beta",
+    "feathers-authentication": "^1.0.0-beta-1",
     "feathers-hooks": "^1.6.1",
     "feathers-memory": "^0.8.1",
     "feathers-rest": "^1.5.2",

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ export default function init (options = {}) {
       // Register 'oauth1' strategy with passport
       debug('Registering oauth1 authentication strategy with options:', oauth1Settings);
       app.passport.use(name, new Strategy(oauth1Settings, verifier.verify.bind(verifier)));
+      app.passport.options(name, oauth1Settings);
 
       return result;
     };

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -105,7 +105,11 @@ class OAuth1Vierifier {
       .find({ query })
       .then(this._normalizeResult)
       .then(entity => entity ? this._updateEntity(entity, data) : this._createEntity(data))
-      .then(entity => done(null, entity))
+      .then(entity => {
+        const id = entity[this.service.id];
+        const payload = { [`${this.options.entity}Id`]: id };
+        done(null, entity, payload);
+      })
       .catch(error => error ? done(error) : done(null, error));
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,6 +101,16 @@ describe('feathers-authentication-oauth1', () => {
       config.Strategy.restore();
     });
 
+    it('registers the strategy options', () => {
+      sinon.spy(app.passport, 'options');
+      app.configure(oauth1(config));
+      app.setup();
+
+      expect(app.passport.options).to.have.been.calledOnce;
+      
+      app.passport.options.restore();
+    });
+
     describe('passport strategy options', () => {
       let authOptions;
       let args;


### PR DESCRIPTION
- returns payload with entityId
- registers strategy options with passport object.

Related to https://github.com/feathersjs/feathers-authentication/pull/349