### PR TITLE
Issue #8: Follow failureRedirect on oauth1 authentication failure

### DIFF
--- a/src/express/error-handler.js
+++ b/src/express/error-handler.js
@@ -1,0 +1,14 @@
+// The default Express error middleware that gets called by the OAuth callback route.
+
+export default function OAuthErrorHandler (options = {}) {
+  return function (err, req, res, next) {
+    // Set __redirect so that later middleware (e.g., auth.express.failureRedirect) can redirect accordingly
+    if (options.failureRedirect) {
+      res.hook = { data: {} };
+      Object.defineProperty(res.hook.data, '__redirect', { value: { status: 302, url: options.failureRedirect } });
+    }
+
+    next(err);
+  };
+}
+

--- a/src/express/handler.js
+++ b/src/express/handler.js
@@ -30,13 +30,6 @@ export default function OAuthHandler (options = {}) {
       }
 
       next();
-    }).catch(error => {
-      if (options.failureRedirect) {
-        res.hook = { data: {} };
-        Object.defineProperty(res.hook.data, '__redirect', { value: { status: 302, url: options.failureRedirect } });
-      }
-
-      next(error);
-    });
+    }).catch(next);
   };
 }

--- a/test/express/error-handler.test.js
+++ b/test/express/error-handler.test.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import errorHandler from '../../src/express/error-handler';
+
+describe('express:error-handler', () => {
+  let req;
+  let res;
+  let error;
+  let options;
+
+  beforeEach(() => {
+    req = {};
+    options = {};
+    res = {
+      hook: {
+        data: {
+          __redirect: {
+            url: '/app'
+          }
+        }
+      }
+    };
+    error = new Error('Authentication Error');
+  });
+
+  describe('when failureRedirect is set', () => {
+    it('sets the redirect object on the response', done => {
+      options.failureRedirect = '/login';
+      errorHandler(options)(error, req, res, () => {
+        expect(res.hook.data.__redirect).to.deep.equal({ status: 302, url: options.failureRedirect });
+        done();
+      });
+    });
+
+    it('calls next with error', done => {
+      delete res.hook;
+      errorHandler(options)(error, req, res, e => {
+        expect(e).to.equal(error);
+        done();
+      });
+    });
+  });
+
+  describe('when failureRedirect is not set', done => {
+    it('calls next with error', done => {
+      delete res.hook;
+      errorHandler(options)(error, req, res, e => {
+        expect(e).to.equal(error);
+        done();
+      });
+    });
+  });
+});

--- a/test/express/handler.test.js
+++ b/test/express/handler.test.js
@@ -89,15 +89,5 @@ describe('express:handler', () => {
         done();
       });
     });
-
-    describe('when failureRedirect is set', () => {
-      it('sets the redirect object on the request', done => {
-        options.failureRedirect = '/login';
-        handler(options)(req, res, () => {
-          expect(res.hook.data.__redirect).to.deep.equal({ status: 302, url: options.failureRedirect });
-          done();
-        });
-      });
-    });
   });
 });


### PR DESCRIPTION
See https://github.com/feathersjs/feathers-authentication-oauth2/pull/11 for the equivalent oauth2 PR