### PR TITLE
Issue #9: Support oauth1 endpoint within sub-app or reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This will set up session middleware and authentication pulling from your global 
 {
     idField: '<provider>Id', // The field to look up the entity by when logging in with the provider. Defaults to '<provider>Id' (ie. 'twitterId').
     path: '/auth/<provider>', // The route to register the middleware
+    callbackPath: '/auth/<provider>/callback', // The route to register the callback handler
     callbackURL: 'http(s)://hostame[:port]/auth/<provider>/callback', // The callback url. Will automatically take into account your host and port and whether you are in production based on your app environment to construct the url. (ie. in development http://localhost:3030/auth/twitter/callback)
     entity: 'user', // the entity that you are looking up
     service: 'users', // the service to look up the entity

--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,12 @@ export default function init (options = {}) {
       idField: `${name}Id`,
       path: `/auth/${name}`,
       session: true,
-      __oauth: true,
-      callbackURL: makeUrl(`/auth/${name}/callback`, app)
+      __oauth: true
     }, pick(authSettings, ...INCLUDE_KEYS), providerSettings, omit(options, ...EXCLUDE_KEYS));
+
+    // Set callback defaults based on provided path
+    oauth1Settings.callbackPath = oauth1Settings.callbackPath || `${oauth1Settings.path}/callback`;
+    oauth1Settings.callbackURL = oauth1Settings.callbackURL || makeUrl(oauth1Settings.callbackPath, app);
 
     if (!oauth1Settings.consumerKey) {
       throw new Error(`You must provide a 'consumerKey' in your authentication configuration or pass one explicitly`);
@@ -65,7 +68,7 @@ export default function init (options = {}) {
     debug(`Registering '${name}' Express OAuth middleware`);
     app.get(oauth1Settings.path, auth.express.authenticate(name));
     app.get(
-      url.parse(oauth1Settings.callbackURL).pathname,
+      oauth1Settings.callbackPath,
       // NOTE (EK): We register failure redirect here so that we can
       // retain the natural express middleware redirect ability like
       // you would have with vanilla passport.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,6 +132,10 @@ describe('feathers-authentication-oauth1', () => {
         expect(args.path).to.equal(`/auth/${config.name}`);
       });
 
+      it('sets callbackPath', () => {
+        expect(args.callbackPath).to.equal(`/auth/${config.name}/callback`);
+      });
+
       it('sets callbackURL', () => {
         expect(args.callbackURL).to.equal(`http://localhost:3030/auth/${config.name}/callback`);
       });
@@ -201,6 +205,17 @@ describe('feathers-authentication-oauth1', () => {
       app.setup();
 
       expect(app.get).to.have.been.calledWith(`/auth/${config.name}/callback`);
+
+      app.get.restore();
+    });
+
+    it('registers custom express callback route', () => {
+      sinon.spy(app, 'get');
+      config.callbackPath = `/v1/api/auth/${config.name}/callback`
+      app.configure(oauth1(config));
+      app.setup();
+
+      expect(app.get).to.have.been.calledWith(config.callbackPath);
 
       app.get.restore();
     });


### PR DESCRIPTION
See https://github.com/feathersjs/feathers-authentication-oauth2/pull/10 for the equivalent oauth2 PR