### PR TITLE
Fix old property name fallback for backwards compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ lib/
 
 # Yarn lockfile
 yarn.lock
+
+# Exclude local vscode settings
+.vscode 

--- a/src/express/handler.js
+++ b/src/express/handler.js
@@ -6,7 +6,7 @@ const debug = Debug('feathers-authentication-oauth1:handler');
 export default function OAuthHandler (options = {}) {
   return function (req, res, next) {
     const app = req.app;
-    const authSettings = app.get('authentication') || {};
+    const authSettings = app.get('auth') || app.get('authentication') || {};
     const entity = req[options.entity];
     const payload = req.payload;
     const params = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import Debug from 'debug';
-import url from 'url';
 import auth from 'feathers-authentication';
 import { formatter as defaultFormatter } from 'feathers-rest';
 import { omit, pick, makeUrl } from 'feathers-commons';
@@ -36,7 +35,7 @@ export default function init (options = {}) {
       throw new Error(`You must provide a passport 'Strategy' instance.`);
     }
 
-    const authSettings = app.get('authentication') || {};
+    const authSettings = app.get('auth') || app.get('authentication') || {};
 
     // Attempt to pull options from the global auth config
     // for this provider.

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default function init (options = {}) {
 
     // register OAuth middleware
     debug(`Registering '${name}' Express OAuth middleware`);
-    app.get(oauth1Settings.path, auth.express.authenticate(name));
+    app.get(oauth1Settings.path, auth.express.authenticate(name, oauth1Settings));
     app.get(
       oauth1Settings.callbackPath,
       // NOTE (EK): We register failure redirect here so that we can

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -112,6 +112,18 @@ describe('feathers-authentication-oauth1', () => {
       app.passport.options.restore();
     });
 
+    it('registers the redirect options on strategy options', () => {
+      sinon.spy(authentication.express, 'authenticate');
+      const mergedOptions = Object.assign({}, config, globalConfig);
+      app.configure(oauth1(mergedOptions));
+      app.setup();
+
+      delete mergedOptions.Strategy;
+      expect(authentication.express.authenticate).to.have.been.calledWith(config.name, sinon.match(mergedOptions));
+
+      authentication.express.authenticate.restore();
+    });
+
     describe('passport strategy options', () => {
       let authOptions;
       let args;


### PR DESCRIPTION
Keeping up with https://github.com/feathersjs/feathers-authentication-oauth2/pull/37 and https://github.com/feathersjs/feathers-authentication-oauth2/pull/44